### PR TITLE
fea: add cache module

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,60 @@
+package cache
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+type CacheStorage interface {
+	Get(key string) ([]byte, error)
+	Set(key string, value []byte) error
+}
+
+type MemCache struct {
+	storage map[string][]byte
+}
+
+var (
+	logger  = log.New(log.Writer(), "cache: ", log.Flags())
+	storage = make(map[string][]byte)
+)
+
+func NewCache() *MemCache {
+	logger.Println("New cache created")
+
+	return &MemCache{
+		storage: storage,
+	}
+}
+
+func (c *MemCache) Get(key string) ([]byte, error) {
+	value, ok := c.storage[key]
+	if !ok {
+		return nil, fmt.Errorf("cache miss for key: %s", key)
+	}
+
+	return value, nil
+}
+
+type CacheOptions struct {
+	ttl int
+}
+
+// interval in seconds, 0 means no ttl
+func WithTTL(ttl int) *CacheOptions {
+	return &CacheOptions{ttl: ttl}
+}
+
+func (c *MemCache) Set(key string, value []byte, opts *CacheOptions) error {
+	if opts != nil && opts.ttl != 0 {
+		go (func() {
+			time.Sleep(time.Duration(opts.ttl) * time.Second)
+			delete(c.storage, key)
+			logger.Printf("key %s has been deleted from cache\n", key)
+		})()
+	}
+
+	c.storage[key] = value
+	return nil
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,6 +1,9 @@
 package cache
 
-import "log"
+import (
+	"log"
+	"time"
+)
 
 var (
 	logger = log.New(log.Writer(), "cache: ", log.Flags())
@@ -13,12 +16,12 @@ type CacheStorage interface {
 }
 
 type CacheOptions struct {
-	ttl int
+	ttl time.Duration
 }
 
 // interval in seconds, 0 means no ttl
 func WithTTL(ttl int) *CacheOptions {
-	return &CacheOptions{ttl: ttl}
+	return &CacheOptions{time.Duration(ttl) * time.Second}
 }
 
 var storageInstance CacheStorage
@@ -33,7 +36,6 @@ func SetStorage(s CacheStorage) error {
 }
 
 func Get(key string) ([]byte, error) {
-	logger.Printf("getting key %s from cache\n", storageInstance)
 	return storageInstance.Get(key)
 }
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -44,7 +44,7 @@ func TestMain(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectedValue, value)
 
-		time.Sleep(1001 * time.Millisecond)
+		time.Sleep(2 * time.Second)
 		_, err = cache.Get("with_ttl")
 		assert.ErrorContains(t, err, "cache miss for key: with_ttl")
 	})

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -9,43 +9,43 @@ import (
 )
 
 func TestMain(t *testing.T) {
-	c := cache.NewCache()
-	if c == nil {
+	if err := cache.SetStorage(cache.NewMemCache()); err != nil {
 		t.Error("Cache should not be nil")
 	}
+
+	defer cache.Flush()
 
 	expectedValue := []byte("value")
 
 	t.Run("Get a missing item", func(t *testing.T) {
-		_, err := c.Get("key")
+		_, err := cache.Get("key")
 
 		assert.ErrorContains(t, err, "cache miss for key: key")
 	})
 
 	t.Run("Set a new item", func(t *testing.T) {
-		err := c.Set("key", expectedValue, nil)
+		err := cache.Set("key", expectedValue, nil)
 		assert.NoError(t, err)
 	})
 
 	t.Run("Get an existing item", func(t *testing.T) {
-		value, err := c.Get("key")
+		value, err := cache.Get("key")
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedValue, value)
 	})
 
 	t.Run("Set a new item with ttl", func(t *testing.T) {
-		err := c.Set("with_ttl", expectedValue, cache.WithTTL(1))
+		err := cache.Set("with_ttl", expectedValue, cache.WithTTL(1))
 		assert.NoError(t, err)
 
 		// assert cache hits value
-		value, err := c.Get("with_ttl")
+		value, err := cache.Get("with_ttl")
 		assert.NoError(t, err)
 		assert.Equal(t, expectedValue, value)
 
 		time.Sleep(1001 * time.Millisecond)
-		_, err = c.Get("with_ttl")
+		_, err = cache.Get("with_ttl")
 		assert.ErrorContains(t, err, "cache miss for key: with_ttl")
-
 	})
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,51 @@
+package cache_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/marco-souza/marco.fly.dev/internal/cache"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(t *testing.T) {
+	c := cache.NewCache()
+	if c == nil {
+		t.Error("Cache should not be nil")
+	}
+
+	expectedValue := []byte("value")
+
+	t.Run("Get a missing item", func(t *testing.T) {
+		_, err := c.Get("key")
+
+		assert.ErrorContains(t, err, "cache miss for key: key")
+	})
+
+	t.Run("Set a new item", func(t *testing.T) {
+		err := c.Set("key", expectedValue, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Get an existing item", func(t *testing.T) {
+		value, err := c.Get("key")
+
+		assert.NoError(t, err)
+		assert.Equal(t, expectedValue, value)
+	})
+
+	t.Run("Set a new item with ttl", func(t *testing.T) {
+		err := c.Set("with_ttl", expectedValue, cache.WithTTL(1))
+		assert.NoError(t, err)
+
+		// assert cache hits value
+		value, err := c.Get("with_ttl")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedValue, value)
+
+		time.Sleep(1001 * time.Millisecond)
+		_, err = c.Get("with_ttl")
+		assert.ErrorContains(t, err, "cache miss for key: with_ttl")
+
+	})
+}

--- a/internal/cache/mem_cache.go
+++ b/internal/cache/mem_cache.go
@@ -27,7 +27,7 @@ func (c MemCache) Get(key string) ([]byte, error) {
 func (c MemCache) Set(key string, value []byte, opts *CacheOptions) error {
 	if opts != nil && opts.ttl != 0 {
 		go (func() {
-			time.Sleep(time.Duration(opts.ttl) * time.Second)
+			time.Sleep(opts.ttl)
 			delete(c.Storage, key)
 			logger.Printf("key %s has been deleted from cache\n", key)
 		})()

--- a/internal/cache/mem_cache.go
+++ b/internal/cache/mem_cache.go
@@ -6,17 +6,17 @@ import (
 )
 
 type MemCache struct {
-	Storage map[string][]byte
+	storage map[string][]byte
 }
 
 func NewMemCache() MemCache {
 	return MemCache{
-		Storage: make(map[string][]byte),
+		storage: make(map[string][]byte),
 	}
 }
 
 func (c MemCache) Get(key string) ([]byte, error) {
-	value, ok := c.Storage[key]
+	value, ok := c.storage[key]
 	if !ok {
 		return nil, fmt.Errorf("cache miss for key: %s", key)
 	}
@@ -28,19 +28,19 @@ func (c MemCache) Set(key string, value []byte, opts *CacheOptions) error {
 	if opts != nil && opts.ttl != 0 {
 		go (func() {
 			time.Sleep(opts.ttl)
-			delete(c.Storage, key)
+			delete(c.storage, key)
 			logger.Printf("key `%s` has been deleted\n", key)
 		})()
 	}
 
-	c.Storage[key] = value
+	c.storage[key] = value
 	logger.Printf("cacheed key `%s`\n", key)
 	return nil
 }
 
 func (c MemCache) Flush() error {
-	for key := range c.Storage {
-		delete(c.Storage, key)
+	for key := range c.storage {
+		delete(c.storage, key)
 	}
 
 	return nil

--- a/internal/cache/mem_cache.go
+++ b/internal/cache/mem_cache.go
@@ -29,11 +29,12 @@ func (c MemCache) Set(key string, value []byte, opts *CacheOptions) error {
 		go (func() {
 			time.Sleep(opts.ttl)
 			delete(c.Storage, key)
-			logger.Printf("key %s has been deleted from cache\n", key)
+			logger.Printf("key `%s` has been deleted\n", key)
 		})()
 	}
 
 	c.Storage[key] = value
+	logger.Printf("cacheed key `%s`\n", key)
 	return nil
 }
 

--- a/internal/cache/mem_cache.go
+++ b/internal/cache/mem_cache.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"fmt"
+	"time"
+)
+
+type MemCache struct {
+	Storage map[string][]byte
+}
+
+func NewMemCache() MemCache {
+	return MemCache{
+		Storage: make(map[string][]byte),
+	}
+}
+
+func (c MemCache) Get(key string) ([]byte, error) {
+	value, ok := c.Storage[key]
+	if !ok {
+		return nil, fmt.Errorf("cache miss for key: %s", key)
+	}
+
+	return value, nil
+}
+
+func (c MemCache) Set(key string, value []byte, opts *CacheOptions) error {
+	if opts != nil && opts.ttl != 0 {
+		go (func() {
+			time.Sleep(time.Duration(opts.ttl) * time.Second)
+			delete(c.Storage, key)
+			logger.Printf("key %s has been deleted from cache\n", key)
+		})()
+	}
+
+	c.Storage[key] = value
+	return nil
+}
+
+func (c MemCache) Flush() error {
+	for key := range c.Storage {
+		delete(c.Storage, key)
+	}
+
+	return nil
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -125,7 +125,7 @@ func fetch(url, method, token string) ([]byte, error) {
 		return body, err
 	}
 
-	// cache content by 1 minutes
+	// cache content by 1 minute
 	cache.Set(cacheKey, body, cache.WithTTL(60))
 
 	return body, nil

--- a/internal/server/routes/pages/private.go
+++ b/internal/server/routes/pages/private.go
@@ -27,7 +27,6 @@ func dashboardHandler(c *fiber.Ctx) error {
 
 	token := github.AccessToken(c)
 	loggedUser, _ := github.User("", token)
-	// TODO: cache user info
 
 	props := dashboardProps{
 		config.DefaultPageParams,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/template/html/v2"
 
+	"github.com/marco-souza/marco.fly.dev/internal/cache"
 	"github.com/marco-souza/marco.fly.dev/internal/config"
 	"github.com/marco-souza/marco.fly.dev/internal/cron"
 	"github.com/marco-souza/marco.fly.dev/internal/db"
@@ -66,6 +67,10 @@ func (s *server) Start() {
 		}
 
 		if err := discord.DiscordService.Open(); err != nil {
+			return err
+		}
+
+		if err := cache.SetStorage(cache.NewMemCache()); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This PR implements a programmatic cache with
- in-memory persistency
- key-value cache
- time to live (TTL)

As next steps, we could:
- [ ] implement a "persistent" cache (with sqlite maybe)

This closes #22 